### PR TITLE
Updated mobile/i18n.js; the babel '~'-rootpath config is actually working

### DIFF
--- a/mobile/i18n.js
+++ b/mobile/i18n.js
@@ -21,10 +21,7 @@ const LOCALES = REACT_APP_LOCALES;
 let FALLBACKTRANSLATIONS = {};
 
 try {
-  const pth = `../../../../${REACT_APP_PUBLIC_LOCALES_OUTPUT}`;
-  FALLBACKTRANSLATIONS = require(pth);
-  // console.debug('~~~ FALLBACK TRANSLATIONS ~~~');
-  // console.debug(FALLBACKTRANSLATIONS);
+  FALLBACKTRANSLATIONS = require("~/" + REACT_APP_PUBLIC_LOCALES_OUTPUT + "/index.js");
 } catch (err) {
   console.log("Cannot load fallback translation files!");
   console.log(err);


### PR DESCRIPTION
figured it out after toying around with async imports, absolute-pathing, etc.; when that worked, I reduced the code. 

turns out dynamic path outside of import/require fails, but concat directly in require/import and "[str]+[str]" instead of `[str]${}[str]` is ok by metro-bundler