### PR TITLE
Replaced deprecated xhrbackend with http-backend

### DIFF
--- a/mobile/i18n.js
+++ b/mobile/i18n.js
@@ -1,7 +1,7 @@
 import i18n from 'i18next';
 import { initReactI18next, useTranslation } from 'react-i18next';
 import Backend from 'i18next-chained-backend';
-import xhrbackend from 'i18next-xhr-backend';
+import HttpApi from 'i18next-http-backend';
 import {
     REACT_APP_BRANCHES,
     REACT_APP_ENV,
@@ -37,7 +37,7 @@ i18n.use(Backend)
         ns: [],
         defaultNS: 'app',
         backend: {
-            backends: [xhrbackend, xhrbackend],
+            backends: [HttpApi, HttpApi],
             backendOptions: [
                 {
                     loadPath: `https://s3.eu-central-1.amazonaws.com/${S3_BUCKET}/${PROJECT_ID}${ENV}{{lng}}/{{ns}}.json`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1521,6 +1521,14 @@
         "@babel/runtime": "^7.4.5"
       }
     },
+    "i18next-http-backend": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-1.0.11.tgz",
+      "integrity": "sha512-5ObfdraKAik+S0Nb8PVCCaTaJgoWm52wf1TwJYVar3kU3lrotzRuhCQrPMmKH4YvrxiN3XsSflR8BtPaP6rcbg==",
+      "requires": {
+        "node-fetch": "2.6.0"
+      }
+    },
     "i18next-parser": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/i18next-parser/-/i18next-parser-1.0.6.tgz",
@@ -1542,14 +1550,6 @@
         "vinyl-fs": "^3.0.2",
         "vue-template-compiler": "^2.6.11",
         "yamljs": "^0.3.0"
-      }
-    },
-    "i18next-xhr-backend": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/i18next-xhr-backend/-/i18next-xhr-backend-3.2.2.tgz",
-      "integrity": "sha512-OtRf2Vo3IqAxsttQbpjYnmMML12IMB5e0fc5B7qKJFLScitYaXa1OhMX0n0X/3vrfFlpHL9Ro/H+ps4Ej2j7QQ==",
-      "requires": {
-        "@babel/runtime": "^7.5.5"
       }
     },
     "iconv-lite": {
@@ -2001,6 +2001,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
         "dotenv": "^8.2.0",
         "i18next": "^19.4.4",
         "i18next-chained-backend": "^2.0.1",
+        "i18next-http-backend": "^1.0.11",
         "i18next-parser": "^1.0.6",
-        "i18next-xhr-backend": "^3.2.2",
         "react-i18next": "^11.4.0",
         "react-native-dotenv": "^0.2.0"
     },

--- a/web/i18n.js
+++ b/web/i18n.js
@@ -1,7 +1,7 @@
 import i18n from 'i18next';
 import { initReactI18next, useTranslation } from 'react-i18next';
 import Backend from 'i18next-chained-backend';
-import xhrbackend from 'i18next-xhr-backend';
+import HttpApi from 'i18next-http-backend';
 const { join } = require('path');
 let ENV = '/';
 
@@ -25,7 +25,7 @@ i18n.use(Backend)
         // NOTE: Keep Empty. Namespaces will be identified + downloaed automatically
         ns: [],
         backend: {
-            backends: [xhrbackend, xhrbackend],
+            backends: [HttpApi, HttpApi],
             backendOptions: [
                 {
                     loadPath: `https://s3.eu-central-1.amazonaws.com/${S3_BUCKET}/${PROJECT_ID}${ENV}{{lng}}/{{ns}}.json`,


### PR DESCRIPTION
xhrbackend is marked as deprecated and succeeded by http-backend. @kirrg001 mentioned that a little while back she ran into issues with the successor, but since they had like 4 releases with fixes in the last 3 weeks, those are resolved. [Release-History](https://github.com/i18next/i18next-http-backend/releases)

switching was really just swapping out the library, so I gave it a shot and tested it with react-native. before merging, please make sure to check if there's still issues left on the react/web portion of the code.

Cheers
-H